### PR TITLE
Fsanzv key password

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,8 +82,9 @@ Checks the validity of a provided certificate and private key, as well as whethe
 
 * __cert__: `String|Buffer` contents of the certificate
 * __key__:  `String|Buffer` contents of the private key
-* __options__: `Object` to verify the certificate against a specific certificate authority, pass
-  the path the CA file in `options.CAfile`
+* __options__: `Object`
+  * to verify the certificate against a specific certificate authority, pass the path the CA file in `options.CAfile`
+  * to use Key password, pass the password in `options.pass`
 * __callback__: `Function` in the form of `callback(err, result)` where `result` is an object
   containing `certStatus`, `keyStatus`, and `match`
   * _result.certStatus_: `Object` containing `Boolean` properties  `valid`, `verifiedCA`, and

--- a/lib/verify.js
+++ b/lib/verify.js
@@ -54,9 +54,21 @@ function verifyCertificate (cert, options, cb) {
 
 var      verifyKey =
 exports. verifyKey =
-function verifyKey (key, cb) {
+function verifyKey (key, options, cb) {
 	var err;
-	var openssl = spawn('openssl', ['rsa', '-noout', '-check']);
+
+	var cliArgs = ['rsa', '-noout', '-check'];
+
+	if (!options) {
+		options = {};
+	} else if (typeof options === 'function') {
+		cb = options;
+		options = {};
+	} else if (options.pass) {
+		cliArgs.push('-passin', "pass:" + options.pass);
+	}
+
+	var openssl = spawn('openssl', cliArgs);
 	function handler (out) {
 		var keyStatus = {valid: true};
 		var data = keyStatus.output = out.toString().trim();
@@ -74,11 +86,26 @@ function verifyKey (key, cb) {
 
 var      compareModuli =
 exports. compareModuli =
-function compareModuli (cert, key, cb) {
+function compareModuli (cert, key, options, cb) {
+
+	if (!options) {
+		options = {};
+	} else if (typeof options === 'function') {
+		cb = options;
+		options = {};
+	}
+
 	var fromCert = spawn('openssl', ['x509', '-noout', '-modulus']);
 	fromCert.stdout.on('data', function (outC) {
 		var certModulus = outC.toString().trim();
-		var fromKey = spawn('openssl', ['rsa', '-noout', '-modulus']);
+
+		var cliArgs = ['rsa', '-noout', '-modulus'];
+
+		if (options.pass) {
+			cliArgs.push('-passin', "pass:" + options.pass);
+		}
+
+		var fromKey = spawn('openssl', cliArgs);
 		fromKey.stdout.on('data', function (outK) {
 			var keyModulus = outK.toString().trim();
 			var result = {
@@ -105,10 +132,10 @@ function verifyCertificateKey (cert, key, options, cb) {
 	verifyCertificate(cert, options, function (err, certStatus) {
 		result.certStatus = certStatus;
 		if (err) {return cb(err, result);}
-		verifyKey(key, function (err, keyStatus) {
+		verifyKey(key, options, function (err, keyStatus) {
 			result.keyStatus = keyStatus;
 			if (err) {return cb(err, result);}
-			compareModuli(cert, key, function (err, moduliResult) {
+			compareModuli(cert, key, options, function (err, moduliResult) {
 				result.match = moduliResult.match;
 				cb(err, result);
 			});


### PR DESCRIPTION
Added password option to verifyKey and compareModuli functions. Password is passed with `-passin pass:key_password` option so it's exposed to `ps` command in Unix systems and must be used with caution.

`-passin stdin` can be used instead `-passin pass:key_password` but i'm unsure how to do it this way. In my tests, it conflicts with passing the key through stdin.
